### PR TITLE
feat(client): Agregar mensaje cuando se intenta meditar con maná lleno

### DIFF
--- a/ui/hub/hub_controller.gd
+++ b/ui/hub/hub_controller.gd
@@ -414,6 +414,7 @@ func _meditate() -> void:
 	var stats = _gameContext.player_stats 
 	
 	if stats.mana == stats.max_mana:
+		ShowConsoleMessage("No puedes entrar en meditación, tu maná ya está completo.", GameAssets.FontDataList[Enums.FontTypeNames.FontType_Info])
 		return
 	
 	if !stats.is_alive():


### PR DESCRIPTION
- Mostrar mensaje informativo cuando el jugador intenta meditar con maná al 100%
- Mensaje: No puedes entrar en meditación, tu maná ya está completo.
- Mejora la retroalimentación al usuario sobre por qué no puede meditar