### PR TITLE
feat(godot): permitir conexión SSL opcional

### DIFF
--- a/engine/autoload/client_interface.gd
+++ b/engine/autoload/client_interface.gd
@@ -7,31 +7,58 @@ signal dataReceived(data:PackedByteArray)
 # Constante para habilitar/deshabilitar el log de paquetes
 const LOG_PACKETS := true
 
-var _socket:StreamPeerTCP = StreamPeerTCP.new()
+var _tcp_peer:StreamPeerTCP = StreamPeerTCP.new()
+var _tls_peer:StreamPeerTLS = null
 var _status:int
+var _use_ssl:bool = false
+var _host_for_ssl:String = ""
+var _tls_pending_error:bool = false
 
 func _ready() -> void:
 	_status = StreamPeerTCP.STATUS_NONE
+	_tls_peer = null
 	set_process(false)
-	
-func ConnectToHost(host:String, port:int) -> void:
+
+func ConnectToHost(host:String, port:int, use_ssl:bool = false) -> void:
+	_use_ssl = use_ssl
+	_host_for_ssl = host
+	_tls_pending_error = false
+	_tls_peer = null
+	_tcp_peer = StreamPeerTCP.new()
 	_status = StreamPeerTCP.STATUS_NONE
-	set_process(_socket.connect_to_host(host, port) == OK)
+	var err := _tcp_peer.connect_to_host(host, port)
+	set_process(err == OK)
+	if err != OK:
+		disconnected.emit()
 
 func DisconnectFromHost() -> void:
-	_socket.disconnect_from_host()
+	if _tls_peer:
+		_tls_peer.disconnect_from_stream()
+		_tls_peer = null
+	_tcp_peer.disconnect_from_host()
+	_use_ssl = false
 
 func Send(data:PackedByteArray) -> void:
-	if _socket.get_status() == StreamPeerTCP.STATUS_CONNECTED && data.size():
-		_socket.put_data(data)
+	if data.size() == 0:
+		return
+
+	if _use_ssl:
+		if _tls_peer and _tls_peer.get_status() == StreamPeerTLS.STATUS_CONNECTED:
+			_tls_peer.put_data(data)
+	elif _tcp_peer.get_status() == StreamPeerTCP.STATUS_CONNECTED:
+		_tcp_peer.put_data(data)
 		
 func _process(_delta: float) -> void:
-	_socket.poll()
-	var newStatus = _socket.get_status()
-	
-	if newStatus != _status:
-		_status = newStatus
-		
+	_tcp_peer.poll()
+	if _use_ssl and _tls_peer:
+		_tls_peer.poll()
+
+	if _use_ssl and _tcp_peer.get_status() == StreamPeerTCP.STATUS_CONNECTED and _tls_peer == null and not _tls_pending_error:
+		_initialize_tls()
+
+	var new_status := _get_effective_status()
+	if new_status != _status:
+		_status = new_status
 		match _status:
 			StreamPeerTCP.STATUS_NONE:
 				disconnected.emit()
@@ -41,36 +68,74 @@ func _process(_delta: float) -> void:
 				connected.emit()
 			StreamPeerTCP.STATUS_ERROR:
 				disconnected.emit()
-			
+				set_process(false)
+
 	if _status == StreamPeerTCP.STATUS_CONNECTED:
-		var availableBytes = _socket.get_available_bytes()
-		if availableBytes > 0:
-			var response = _socket.get_partial_data(availableBytes)
-			
-			if response[0] != OK:
-				disconnected.emit()
-				set_process(false);
-			else:
-				var data = response[1]
-				if LOG_PACKETS and data.size() > 0:
-					# Mostrar información básica del paquete
-					var packet_id = -1
-					var packet_length = 0
-					
-					# Obtener el ID del paquete (primer byte)
-					if data.size() >= 1:
-						packet_id = data[0]
-					
-					# Obtener la longitud del paquete (bytes 2 y 3, little-endian)
-					if data.size() >= 3:
-						packet_length = (data[2] << 8) | data[1]
-					
-					# Convertir los primeros bytes a formato legible
-					var hex_str = ""
-					for i in range(min(8, data.size())):
-						hex_str += "%02X " % data[i]
-					
-					# Mostrar información del paquete
-					print("[INCOMING] Packet ID: %d (0x%02X), Longitud: %d, Bytes: %s" % [packet_id, packet_id, packet_length, hex_str])
-				
-				dataReceived.emit(data)
+		var peer := _get_active_peer()
+		if peer:
+			var available_bytes := peer.get_available_bytes()
+			if available_bytes > 0:
+				var response := peer.get_partial_data(available_bytes)
+				if response[0] != OK:
+					disconnected.emit()
+					set_process(false)
+				else:
+					var data:PackedByteArray = response[1]
+					if LOG_PACKETS and data.size() > 0:
+						var packet_id := -1
+						var packet_length := 0
+						if data.size() >= 1:
+							packet_id = data[0]
+						if data.size() >= 3:
+							packet_length = (data[2] << 8) | data[1]
+						var hex_str := ""
+						for i in range(min(8, data.size())):
+							hex_str += "%02X " % data[i]
+						print("[INCOMING] Packet ID: %d (0x%02X), Longitud: %d, Bytes: %s" % [packet_id, packet_id, packet_length, hex_str])
+					dataReceived.emit(data)
+
+func _initialize_tls() -> void:
+	_tls_peer = StreamPeerTLS.new()
+	var tls_options := TLSOptions.client_unsafe()
+	var err := _tls_peer.connect_to_stream(_tcp_peer, _host_for_ssl, tls_options)
+	if err != OK:
+		push_error("No se pudo iniciar conexión TLS: %s" % [err])
+		_tls_peer = null
+		_tls_pending_error = true
+
+func _get_effective_status() -> int:
+	var tcp_status := _tcp_peer.get_status()
+	if not _use_ssl:
+		return tcp_status
+
+	if tcp_status == StreamPeerTCP.STATUS_ERROR:
+		return tcp_status
+	if tcp_status == StreamPeerTCP.STATUS_NONE:
+		return tcp_status
+	if tcp_status == StreamPeerTCP.STATUS_CONNECTING:
+		return tcp_status
+	if _tls_pending_error:
+		return StreamPeerTCP.STATUS_ERROR
+	if _tls_peer == null:
+		return StreamPeerTCP.STATUS_CONNECTING
+
+	var tls_status := _tls_peer.get_status()
+	match tls_status:
+		StreamPeerTLS.STATUS_HANDSHAKING:
+			return StreamPeerTCP.STATUS_CONNECTING
+		StreamPeerTLS.STATUS_CONNECTED:
+			return StreamPeerTCP.STATUS_CONNECTED
+		StreamPeerTLS.STATUS_DISCONNECTED:
+			_tls_peer = null
+			return StreamPeerTCP.STATUS_NONE
+		StreamPeerTLS.STATUS_ERROR:
+			_tls_peer = null
+			_tls_pending_error = true
+			return StreamPeerTCP.STATUS_ERROR
+		_:
+			return StreamPeerTCP.STATUS_CONNECTING
+
+func _get_active_peer() -> StreamPeer:
+	if _use_ssl and _tls_peer and _tls_peer.get_status() == StreamPeerTLS.STATUS_CONNECTED:
+		return _tls_peer
+	return _tcp_peer

--- a/engine/autoload/saved_credentials.gd
+++ b/engine/autoload/saved_credentials.gd
@@ -1,6 +1,7 @@
 extends Node
 
 const CREDENTIALS_FILE = "user://saved_credentials.dat"
+const SSL_FILE = "user://network_settings.cfg"
 
 func save_credentials(username: String, password: String) -> void:
 	var file = FileAccess.open(CREDENTIALS_FILE, FileAccess.WRITE)
@@ -22,3 +23,14 @@ func load_credentials() -> Dictionary:
 func clear_credentials() -> void:
 	if FileAccess.file_exists(CREDENTIALS_FILE):
 		DirAccess.remove_absolute(CREDENTIALS_FILE)
+
+func save_ssl_preference(enabled: bool) -> void:
+	var cfg = ConfigFile.new()
+	cfg.set_value("network", "use_ssl", enabled)
+	cfg.save(SSL_FILE)
+
+func load_ssl_preference() -> bool:
+	var cfg = ConfigFile.new()
+	if cfg.load(SSL_FILE) == OK:
+		return bool(cfg.get_value("network", "use_ssl", false))
+	return false

--- a/screens/login_screen.gd
+++ b/screens/login_screen.gd
@@ -60,12 +60,12 @@ func _HandleLogged(data:PackedByteArray) -> void:
 	ScreenController.SwitchScreen(screen)
 		
 func _OnLoginPanelSubmit() -> void:
-	_ConnectToHost(State.Login)
-		
+	_ConnectToHost(State.Login, _loginPanel.IsSSLSelected())
+
 func _OnLoginPanelRegister() -> void:
-	_ConnectToHost(State.NewPj)
+	_ConnectToHost(State.NewPj, _loginPanel.IsSSLSelected())
 		
-func _ConnectToHost(state:State) -> void:
+func _ConnectToHost(state:State, use_ssl:bool = false) -> void:
 	#if ClientInterface.IsConnected():
 	#	ClientInterface.DisconnectFromHost()
 		
@@ -73,7 +73,7 @@ func _ConnectToHost(state:State) -> void:
 	_loginPanel.DisableAuthControls()
 	
 	var endpoint = _GetEnpoint()
-	ClientInterface.ConnectToHost(endpoint.ip, endpoint.port)
+	ClientInterface.ConnectToHost(endpoint.ip, endpoint.port, use_ssl)
 
 func _Flush() -> void:
 	ClientInterface.Send(GameProtocol.Flush());

--- a/ui/login_panel.gd
+++ b/ui/login_panel.gd
@@ -18,6 +18,8 @@ func _ready() -> void:
 		%Password.text = credentials.password
 		%RememberPassword.button_pressed = true
 
+	%UseSSL.button_pressed = SavedCredentials.load_ssl_preference()
+
 func _on_show_password_toggled(button_pressed: bool) -> void:
 	%Password.secret = !button_pressed
 	if button_pressed:
@@ -79,5 +81,10 @@ func _OnButtonLoginPressed() -> void:
 		SavedCredentials.save_credentials(%Username.text, %Password.text)
 	else:
 		SavedCredentials.clear_credentials()
-	
+
+	SavedCredentials.save_ssl_preference(%UseSSL.button_pressed)
+
 	submit.emit()
+
+func IsSSLSelected() -> bool:
+	return %UseSSL.button_pressed

--- a/ui/login_panel.tscn
+++ b/ui/login_panel.tscn
@@ -70,6 +70,11 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Recordar contraseña"
 
+[node name="UseSSL" type="CheckBox" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Usar conexión SSL"
+
 [node name="MarginContainer3" type="MarginContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_bottom = 10


### PR DESCRIPTION
## Resumen (Cliente Godot)

- Añade checkbox “Usar conexión SSL” en el panel de login, guardando la preferencia del usuario.
- Actualiza la lógica de conexión para usar `StreamPeerTLS` con `TLSOptions.client_unsafe()` cuando se selecciona SSL.
- Extiende `SavedCredentials` para persistir la preferencia de SSL junto con usuario/contraseña.

### Archivos Modificados
- [clientes/ArgentumOnlineGodot/ui/login_panel.tscn](cci:7://file:///home/cristian/repos/propios/pyao-server/clientes/ArgentumOnlineGodot/ui/login_panel.tscn:0:0-0:0)
- [clientes/ArgentumOnlineGodot/ui/login_panel.gd](cci:7://file:///home/cristian/repos/propios/pyao-server/clientes/ArgentumOnlineGodot/ui/login_panel.gd:0:0-0:0)
- [clientes/ArgentumOnlineGodot/screens/login_screen.gd](cci:7://file:///home/cristian/repos/propios/pyao-server/clientes/ArgentumOnlineGodot/screens/login_screen.gd:0:0-0:0)
- [clientes/ArgentumOnlineGodot/engine/autoload/client_interface.gd](cci:7://file:///home/cristian/repos/propios/pyao-server/clientes/ArgentumOnlineGodot/engine/autoload/client_interface.gd:0:0-0:0)
- [clientes/ArgentumOnlineGodot/engine/autoload/saved_credentials.gd](cci:7://file:///home/cristian/repos/propios/pyao-server/clientes/ArgentumOnlineGodot/engine/autoload/saved_credentials.gd:0:0-0:0)

### Pruebas
- Conexión manual Godot → servidor con SSL activado y desactivado.