### PR TITLE
fix(client): Enviar parámetro username en comando /PARTY

### DIFF
--- a/engine/autoload/game_protocol.gd
+++ b/engine/autoload/game_protocol.gd
@@ -370,9 +370,10 @@ static func WritePartyCreate() -> void:
 	_writer.put_u8(Enums.ClientPacketID.PartyCreate)
 
 
-static func WritePartyJoin() -> void:
+static func WritePartyJoin(nickname: String) -> void:
 	_log_outgoing_packet("PartyJoin")
 	_writer.put_u8(Enums.ClientPacketID.PartyJoin)
+	_writer.put_string(nickname)
 
 
 static func WriteShareNpc() -> void:

--- a/ui/hub/console_command_processor.gd
+++ b/ui/hub/console_command_processor.gd
@@ -318,7 +318,12 @@ static func party_join(args:ChatCommandArgs) -> void:
 		args.hub_controller.ShowConsoleMessage("¡¡Estás muerto!!", GameAssets.FontDataList[Enums.FontTypeNames.FontType_Info])
 		return
 	
-	GameProtocol.WritePartyJoin()
+	if args.parameters.size() == 0:
+		args.hub_controller.ShowConsoleMessage("Debes especificar un nombre de usuario. Uso: /PARTY <nombre>", GameAssets.FontDataList[Enums.FontTypeNames.FontType_Info])
+		return
+	
+	var nickname = args.parameters[0]
+	GameProtocol.WritePartyJoin(nickname)
 
 
 static func share_npc(args:ChatCommandArgs) -> void:


### PR DESCRIPTION
- Modificado `WritePartyJoin()` para enviar el username del jugador a invitar
- Agregado `_writer.put_string(nickname)` en [game_protocol.gd](engine/autoload/game_protocol.gd:0:0-0:0)
- Corregido formato de paquete: [packet_id][length][username]
- Ahora el servidor recibe correctamente el nombre del jugador objetivo

Fixes: Error #struct.error: unpack requires a buffer of 1 bytes# en servidor